### PR TITLE
Activate travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,59 @@
+sudo: false
+notifications:
+  irc:
+    channels: "chat.freenode.net#firedrake"
+    skip_join: true
+    on_success: change
+    on_failure: always
+    template: "%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message} | %{build_url}"
+
+language: python
+python: "2.7"
+addons:
+  apt:
+    packages:
+        - build-essential
+        - python-dev
+        - git
+        - mercurial
+        - python-pip
+        - python-scipy
+        - libopenmpi-dev
+        - openmpi-bin
+        - libblas-dev
+        - liblapack-dev
+        - gfortran
+        - libspatialindex-dev
+        - swig
+os:
+  - linux
+
+cache:
+  directories:
+    - $HOME/install/firedrake/
+    - $HOME/ffc_kernels/
+
+env:
+  global:
+    - CC=mpicc
+    - FIREDRAKE_FFC_KERNEL_CACHE_DIR=$HOME/ffc_kernels/
+    - PETSC_CONFIGURE_OPTIONS="--download-mumps --download-scalapack --download-parmetis --download-metis"
+
+before_install:
+  - pip install -U pip
+  - pip install -U virtualenv
+
+install:
+  - mkdir -p $HOME/install
+  - pushd $HOME/install
+  - curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-install
+  # Check for cached install
+  - if [[ ! -f ./firedrake/bin/activate ]]; then python ./firedrake-install --disable-ssh --minimal-petsc --package-branch ffc cofs --package-branch ufl cofs --package_branch firedrake cofs; fi
+  - . ./firedrake/bin/activate
+  - pip install pytest
+  - popd
+  - pip install -r requirements.txt
+  # Make cofs visible, don't want to pip install it, because then it will be cached by travis
+  - export PYTHONPATH=`pwd`:$PYTHONPATH
+script:
+  - py.test -v test

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,4 @@ install:
   # Make cofs visible, don't want to pip install it, because then it will be cached by travis
   - export PYTHONPATH=`pwd`:$PYTHONPATH
 script:
-  - py.test -v test
+  - py.test --travis -v test

--- a/cofs/utility.py
+++ b/cofs/utility.py
@@ -19,8 +19,6 @@ from cofs.fieldDefs import fieldMetadata
 comm = op2.MPI.comm
 commrank = op2.MPI.comm.rank
 
-colorama.init()
-
 
 class frozenClass(object):
     """A class where creating a new attribute will raise an exception if _isfrozen == True"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+colorama

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,3 +15,31 @@ def pytest_runtest_setup(item):
     not_travis = item.get_marker("not_travis")
     if not_travis is not None and item.config.getoption("--travis"):
         pytest.skip("Skipping test marked not for Travis")
+
+
+# Print a progress "." once a minute when running in travis mode
+# This is an attempt to stop travis timing the builds out due to lack
+# of output.
+progress_process = None
+
+
+def pytest_configure(config):
+    global progress_process
+    if config.getoption("--travis") and progress_process is None:
+        import multiprocessing
+        import py
+        terminal = py.io.TerminalWriter()
+        def writer():
+            import time
+            while True:
+                terminal.write("still alive\n")
+                time.sleep(60)
+        progress_process = multiprocessing.Process(target=writer)
+        progress_process.daemon = True
+        progress_process.start()
+
+
+def pytest_unconfigure(config):
+    global progress_process
+    if config.getoption("--travis") and progress_process is not None:
+        progress_process.terminate()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--travis", action="store_true", default=False,
+                     help="Only run tests marked for Travis")
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers",
+                            "not_travis: Mark a test that should not be run on Travis")
+
+
+def pytest_runtest_setup(item):
+    not_travis = item.get_marker("not_travis")
+    if not_travis is not None and item.config.getoption("--travis"):
+        pytest.skip("Skipping test marked not for Travis")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -48,5 +48,16 @@ def pytest_unconfigure(config):
 def pytest_runtest_teardown(item, nextitem):
     """Clear COFS caches after running a test"""
     from cofs.utility import linProblemCache, tmpFunctionCache
+    from firedrake.ffc_interface import FFCKernel
+    from pyop2.op2 import Kernel
+    from pyop2.base import JITModule
+
     linProblemCache.clear()
     tmpFunctionCache.clear()
+
+    # disgusting hack, clear the Class-Cached objects in PyOP2 and
+    # Firedrake, otherwise these will never be collected.  The Kernels
+    # get very big with bendy on.
+    Kernel._cache.clear()
+    FFCKernel._cache.clear()
+    JITModule._cache.clear()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -43,3 +43,10 @@ def pytest_unconfigure(config):
     global progress_process
     if config.getoption("--travis") and progress_process is not None:
         progress_process.terminate()
+
+
+def pytest_runtest_teardown(item, nextitem):
+    """Clear COFS caches after running a test"""
+    from cofs.utility import linProblemCache, tmpFunctionCache
+    linProblemCache.clear()
+    tmpFunctionCache.clear()

--- a/test/continuity3d/test_continuity_mes.py
+++ b/test/continuity3d/test_continuity_mes.py
@@ -6,6 +6,7 @@ Tuomas Karna 2015-10-23
 from cofs import *
 import numpy
 from scipy import stats
+import pytest
 
 
 def setup1(Lx, h0, mimetic=True):
@@ -393,6 +394,7 @@ def run_convergence(setup, ref_list, order, export=False, savePlot=False):
 # ---------------------------
 
 
+@pytest.mark.not_travis
 def test_setup5_dg():
     run_convergence(setup5dg, [1, 2, 3], 1, savePlot=False)
 

--- a/test/operations/test_operations_2d-3d.py
+++ b/test/operations/test_operations_2d-3d.py
@@ -1,139 +1,158 @@
-import unittest
+import pytest
+from firedrake import *
+import cofs.utility as utility
 import numpy as np
 
 
-class mesh2d3dOperationsBase(object):
-
-    def createSpaces(self, fs_name, fs_order, vfs_name, vfs_order):
-        from firedrake import *
-        mesh2d = UnitSquareMesh(5, 5)
-        mesh = ExtrudedMesh(mesh2d, layers=10, layer_height=-0.1)
-
-        P1_2d = FunctionSpace(mesh2d, fs_name, fs_order)
-        U_2d = VectorFunctionSpace(mesh2d, fs_name, fs_order)
-
-        P1 = FunctionSpace(mesh, fs_name, fs_order,
-                           vfamily=vfs_name, vdegree=vfs_order)
-        U = VectorFunctionSpace(mesh, fs_name, fs_order,
-                                vfamily=vfs_name, vdegree=vfs_order)
-
-        self.uv_3d = Function(U, name='Velocity')
-        self.uv_3dint = Function(U, name='Velocity')
-        self.uv_2d = Function(U_2d, name='Velocity')
-
-        self.uv_3d_x = Function(U, name='Velocity')
-        self.uv_2d_x = Function(U_2d, name='Velocity')
-
-        self.c3d = Function(P1, name='Tracer')
-        self.c2d = Function(P1_2d, name='Tracer')
-
-        self.c3d_x = Function(P1, name='Tracer')
-        self.c2d_x = Function(P1_2d, name='Tracer')
-
-        self.const3d = Function(P1)
-        self.const3d.interpolate(Expression(('3.0')))
-
-        self.c3d.interpolate(Expression(('x[2] + 2.0')))
-        self.c2d.interpolate(Expression(('4.0')))
-        self.c3d_x.interpolate(Expression(('x[0] + 2.0')))
-        self.c2d_x.interpolate(Expression(('2*x[0]')))
-        self.uv_3d.interpolate(Expression(('x[2] + 1.0', '2.0*x[2] + 4.0', '3.0*x[2] + 6.0')))
-        self.uv_2d.interpolate(Expression(('4.0', '8.0')))
-        self.uv_3d_x.interpolate(Expression(('x[0] + 1.0', '2.0*x[1] + 4.0', '3.0*x[0]*x[2] + 6.0')))
-        self.uv_2d_x.interpolate(Expression(('4.0*x[0]', '8.0*x[1]')))
-
-    def test_copy3dFieldTo2d(self):
-        import cofs.utility as utility
-        utility.copy3dFieldTo2d(self.c3d, self.c2d, useBottomValue=True)
-        self.assertTrue(np.allclose(self.c2d.dat.data[:], 1.0))
-
-        utility.copy3dFieldTo2d(self.c3d, self.c2d, useBottomValue=False)
-        self.assertTrue(np.allclose(self.c2d.dat.data[:], 2.0))
-
-    def test_copy3dFieldTo2d_vec(self):
-        import cofs.utility as utility
-        utility.copy3dFieldTo2d(self.uv_3d, self.uv_2d, useBottomValue=True)
-        self.assertTrue(np.allclose(self.uv_2d.dat.data[:, 0], 0.0))
-        self.assertTrue(np.allclose(self.uv_2d.dat.data[:, 1], 2.0))
-
-        utility.copy3dFieldTo2d(self.uv_3d, self.uv_2d, useBottomValue=False)
-        self.assertTrue(np.allclose(self.uv_2d.dat.data[:, 0], 1.0))
-        self.assertTrue(np.allclose(self.uv_2d.dat.data[:, 1], 4.0))
-
-    def test_copy3dFieldTo2d_x(self):
-        import cofs.utility as utility
-        utility.copy3dFieldTo2d(self.c3d_x, self.c2d_x, useBottomValue=True)
-        self.assertTrue(np.allclose(self.c2d_x.dat.data.min(), 2.0))
-        self.assertTrue(np.allclose(self.c2d_x.dat.data.max(), 3.0))
-
-        utility.copy3dFieldTo2d(self.c3d_x, self.c2d_x, useBottomValue=False)
-        self.assertTrue(np.allclose(self.c2d_x.dat.data.min(), 2.0))
-        self.assertTrue(np.allclose(self.c2d_x.dat.data.max(), 3.0))
-
-    def test_copy3dFieldTo2d_x_vec(self):
-        import cofs.utility as utility
-        utility.copy3dFieldTo2d(self.uv_3d_x, self.uv_2d_x, useBottomValue=True)
-        self.assertTrue(np.allclose(self.uv_2d_x.dat.data[:, 0].min(), 1.0))
-        self.assertTrue(np.allclose(self.uv_2d_x.dat.data[:, 0].max(), 2.0))
-        self.assertTrue(np.allclose(self.uv_2d_x.dat.data[:, 1].min(), 4.0))
-        self.assertTrue(np.allclose(self.uv_2d_x.dat.data[:, 1].max(), 6.0))
-
-        utility.copy3dFieldTo2d(self.uv_3d_x, self.uv_2d_x, useBottomValue=False)
-        self.assertTrue(np.allclose(self.uv_2d_x.dat.data[:, 0].min(), 1.0))
-        self.assertTrue(np.allclose(self.uv_2d_x.dat.data[:, 0].max(), 2.0))
-        self.assertTrue(np.allclose(self.uv_2d_x.dat.data[:, 1].min(), 4.0))
-        self.assertTrue(np.allclose(self.uv_2d_x.dat.data[:, 1].max(), 6.0))
-
-    def test_copy2dFieldTo3d(self):
-        import cofs.utility as utility
-        utility.copy2dFieldTo3d(self.c2d, self.c3d)
-        self.assertTrue(np.allclose(self.c3d.dat.data[:], 4.0))
-
-    def test_copy2dFieldTo3d_x(self):
-        import cofs.utility as utility
-        utility.copy2dFieldTo3d(self.c2d_x, self.c3d_x)
-        self.assertTrue(np.allclose(self.c3d_x.dat.data.min(), 0.0))
-        self.assertTrue(np.allclose(self.c3d_x.dat.data.max(), 2.0))
-
-    def test_copy2dFieldTo3d_x_vec(self):
-        import cofs.utility as utility
-        utility.copy2dFieldTo3d(self.uv_2d_x, self.uv_3d_x)
-        self.assertTrue(np.allclose(self.uv_3d_x.dat.data[:, 0].min(), 0.0))
-        self.assertTrue(np.allclose(self.uv_3d_x.dat.data[:, 0].max(), 4.0))
-        self.assertTrue(np.allclose(self.uv_3d_x.dat.data[:, 1].min(), 0.0))
-        self.assertTrue(np.allclose(self.uv_3d_x.dat.data[:, 1].max(), 8.0))
-
-    def test_copy2dFieldTo3d_vec(self):
-        import cofs.utility as utility
-        utility.copy2dFieldTo3d(self.uv_2d, self.uv_3d)
-        self.assertTrue(np.allclose(self.uv_3d.dat.data[:, 0], 4.0))
-        self.assertTrue(np.allclose(self.uv_3d.dat.data[:, 1], 8.0))
+@pytest.fixture(scope="module")
+def mesh2d():
+    return UnitSquareMesh(5, 5)
 
 
-class test_mesh2d3dOperationsP1(mesh2d3dOperationsBase, unittest.TestCase):
-
-    def setUp(self):
-        mesh2d3dOperationsBase.createSpaces(self, 'CG', 1, 'CG', 1)
-
-
-class test_mesh2d3dOperationsP2(mesh2d3dOperationsBase, unittest.TestCase):
-
-    def setUp(self):
-        mesh2d3dOperationsBase.createSpaces(self, 'CG', 2, 'CG', 2)
+@pytest.fixture(scope="module")
+def mesh(mesh2d):
+    return ExtrudedMesh(mesh2d, layers=10, layer_height=-0.1)
 
 
-class test_mesh2d3dOperationsP1DG(mesh2d3dOperationsBase, unittest.TestCase):
-    # FIXME somehow DG tests fail if ran in combination with CG tests?
-    def setUp(self):
-        mesh2d3dOperationsBase.createSpaces(self, 'DG', 1, 'DG', 1)
+@pytest.fixture(params=["P1xP1", "P2xP2", "P1DGxP1DG", "P2DGxP2DG"])
+def spaces(request):
+    if request.param == "P1xP1":
+        return (("CG", 1), ("CG", 1))
+    elif request.param == "P2xP2":
+        return (("CG", 2), ("CG", 2))
+    elif request.param == "P1DGxP1DG":
+        return (("DG", 1), ("DG", 1))
+    elif request.param == "P2DGxP2DG":
+        return (("DG", 2), ("DG", 2))
 
 
-class test_mesh2d3dOperationsP2DG(mesh2d3dOperationsBase, unittest.TestCase):
-    # FIXME somehow DG tests fail if ran in combination with CG tests?
-    def setUp(self):
-        mesh2d3dOperationsBase.createSpaces(self, 'DG', 2, 'DG', 2)
+@pytest.fixture
+def P1_2d(mesh2d, spaces):
+    (name, order), (vname, vorder) = spaces
+    return FunctionSpace(mesh2d, name, order)
 
+
+@pytest.fixture
+def P1(mesh, spaces):
+    (name, order), (vname, vorder) = spaces
+    return FunctionSpace(mesh, name, order,
+                         vfamily=vname, vdegree=vorder)
+
+@pytest.fixture
+def U_2d(mesh2d, spaces):
+    (name, order), (vname, vorder) = spaces
+    return VectorFunctionSpace(mesh2d, name, order)
+
+@pytest.fixture
+def U(mesh, spaces):
+    (name, order), (vname, vorder) = spaces
+    return VectorFunctionSpace(mesh, name, order,
+                               vfamily=vname, vdegree=vorder)
+
+
+@pytest.fixture
+def c3d(P1):
+    return Function(P1, name="Tracer").interpolate(Expression("x[2] + 2.0"))
+
+
+@pytest.fixture
+def c3d_x(P1):
+    return Function(P1, name="Tracer").interpolate(Expression("x[0] + 2.0"))
+
+
+@pytest.fixture
+def c2d(P1_2d):
+    return Function(P1_2d, name="Tracer").interpolate(Expression("4.0"))
+
+
+@pytest.fixture
+def c2d_x(P1_2d):
+    return Function(P1_2d, name="Tracer").interpolate(Expression("2*x[0]"))
+
+
+@pytest.fixture
+def uv_3d(U):
+    return Function(U, name="Velocity").interpolate(Expression(('x[2] + 1.0',
+                                                                '2.0*x[2] + 4.0',
+                                                                '3.0*x[2] + 6.0')))
+
+
+@pytest.fixture
+def uv_3d_x(U):
+    return Function(U, name="Velocity").interpolate(Expression(('x[0] + 1.0',
+                                                                '2.0*x[1] + 4.0',
+                                                                '3.0*x[0]*x[2] + 6.0')))
+
+
+@pytest.fixture
+def uv_2d(U_2d):
+    return Function(U_2d, name="Velocity").interpolate(Expression(('4.0', '8.0')))
+
+
+@pytest.fixture
+def uv_2d_x(U_2d):
+    return Function(U_2d, name="Velocity").interpolate(Expression(('4.0*x[0]', '8.0*x[1]')))
+
+
+@pytest.mark.parametrize("bottom",
+                         ([True, 1.0],
+                          [False, 2.0]))
+def test_copy3dFieldTo2d(c3d, c2d, bottom):
+    bottom, expect = bottom
+    utility.copy3dFieldTo2d(c3d, c2d, useBottomValue=bottom)
+    assert np.allclose(c2d.dat.data_ro[:], expect)
+
+
+@pytest.mark.parametrize("bottom",
+                         ([True, (0.0, 2.0)],
+                          [False, (1.0, 4.0)]))
+def test_copy3dFieldTo2d_vec(uv_3d, uv_2d, bottom):
+    bottom, expect = bottom
+    utility.copy3dFieldTo2d(uv_3d, uv_2d, useBottomValue=bottom)
+    assert np.allclose(uv_2d.dat.data_ro, expect)
+
+
+@pytest.mark.parametrize("bottom", (True, False))
+def test_copy3dFieldTo2d_x(c3d_x, c2d_x, bottom):
+    utility.copy3dFieldTo2d(c3d_x, c2d_x, useBottomValue=bottom)
+    assert np.allclose(c2d_x.dat.data_ro.min(), 2.0)
+    assert np.allclose(c2d_x.dat.data_ro.max(), 3.0)
+
+
+@pytest.mark.parametrize("bottom", (True, False))
+def test_copy3dFieldTo2d_x_vec(uv_3d_x, uv_2d_x, bottom):
+    utility.copy3dFieldTo2d(uv_3d_x, uv_2d_x, useBottomValue=bottom)
+    assert np.allclose(uv_2d_x.dat.data_ro[:, 0].min(), 1.0)
+    assert np.allclose(uv_2d_x.dat.data_ro[:, 0].max(), 2.0)
+    assert np.allclose(uv_2d_x.dat.data_ro[:, 1].min(), 4.0)
+    assert np.allclose(uv_2d_x.dat.data_ro[:, 1].max(), 6.0)
+
+
+def test_copy2dFieldTo3d(c2d, c3d):
+    utility.copy2dFieldTo3d(c2d, c3d)
+    assert np.allclose(c3d.dat.data_ro[:], 4.0)
+
+
+def test_copy2dFieldTo3d_x(c2d_x, c3d_x):
+    utility.copy2dFieldTo3d(c2d_x, c3d_x)
+    assert np.allclose(c3d_x.dat.data_ro.min(), 0.0)
+    assert np.allclose(c3d_x.dat.data_ro.max(), 2.0)
+
+
+def test_copy2dFieldTo3d_x_vec(uv_2d_x, uv_3d_x):
+    utility.copy2dFieldTo3d(uv_2d_x, uv_3d_x)
+    assert np.allclose(uv_3d_x.dat.data_ro[:, 0].min(), 0.0)
+    assert np.allclose(uv_3d_x.dat.data_ro[:, 0].max(), 4.0)
+    assert np.allclose(uv_3d_x.dat.data_ro[:, 1].min(), 0.0)
+    assert np.allclose(uv_3d_x.dat.data_ro[:, 1].max(), 8.0)
+
+
+def test_copy2dFieldTo3d_vec(uv_2d, uv_3d):
+    utility.copy2dFieldTo3d(uv_2d, uv_3d)
+    assert np.allclose(uv_3d.dat.data_ro[:, 0], 4.0)
+    assert np.allclose(uv_3d.dat.data_ro[:, 1], 8.0)
 
 if __name__ == '__main__':
     """Run all tests"""
-    unittest.main()
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/test/swe2d/test_steady_state_basin_mms.py
+++ b/test/swe2d/test_steady_state_basin_mms.py
@@ -13,6 +13,7 @@ Tuomas Karna 2015-10-29
 from cofs import *
 import numpy
 from scipy import stats
+import pytest
 
 
 def setup1(Lx, Ly, depth, f0, g, mimetic=True):
@@ -542,20 +543,18 @@ def run_convergence(setup, ref_list, order, export=False, savePlot=False):
 # ---------------------------
 
 
-def test_setup7_mimetic():
-    run_convergence(setup7, [1, 2, 4, 6], 1, savePlot=False)
+@pytest.fixture(params=[setup7, setup8], ids=["Setup7", "Setup8"])
+def choose_setup(request):
+    return request.param
 
 
-def test_setup8_mimetic():
-    run_convergence(setup8, [1, 2, 4, 6], 1, savePlot=False)
+@pytest.fixture(params=[False, True], ids=["DG", "mimetic"])
+def setup_function(request, choose_setup):
+    return lambda *args: choose_setup(*args, mimetic=request.param)
 
 
-def test_setup7_dg():
-    run_convergence(setup7dg, [1, 2, 4, 6], 1, savePlot=False)
-
-
-def test_setup8_dg():
-    run_convergence(setup8dg, [1, 2, 4, 6], 1, savePlot=False)
+def test_steady_state_basin_convergence(setup_function):
+    run_convergence(setup_function, [1, 2, 4, 6], 1, savePlot=False)
 
 # ---------------------------
 # run individual setup for debugging


### PR DESCRIPTION
Sets up build testing on travis.  This branch is tested, for example, here: https://travis-ci.org/wence-/cofs/builds/96775578

Also pytestifies some of the tests using fixtures.

The travis testing framework uses travis caching to mean that we don't have to reinstall firedrake every time (also the FFC kernel cache is cached, so only the first run should require building the kernels).  These need to be manually invalidated if the dependencies are upgraded (but this is a one-click thing on the travis website).

I didn't activate code linting, because most of the source tree fails it!