### PR TITLE
Updates for current Firedrake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,19 +24,16 @@ addons:
         - liblapack-dev
         - gfortran
         - libspatialindex-dev
-        - swig
 os:
   - linux
 
 cache:
   directories:
     - $HOME/install/firedrake/
-    - $HOME/ffc_kernels/
 
 env:
   global:
     - CC=mpicc
-    - FIREDRAKE_FFC_KERNEL_CACHE_DIR=$HOME/ffc_kernels/
     - PETSC_CONFIGURE_OPTIONS="--download-mumps --download-scalapack --download-parmetis --download-metis"
 
 before_install:
@@ -49,7 +46,7 @@ install:
   - pushd $HOME/install
   - curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-install
   # Check for cached install
-  - if [[ ! -f ./firedrake/bin/activate ]]; then python ./firedrake-install --disable-ssh --minimal-petsc --package-branch ffc cofs --package-branch ufl cofs --package_branch firedrake cofs; fi
+  - if [[ ! -f ./firedrake/bin/activate ]]; then python ./firedrake-install --disable-ssh --minimal-petsc; fi
   - . ./firedrake/bin/activate
   - pip install pytest
   - popd

--- a/cofs/limiter.py
+++ b/cofs/limiter.py
@@ -66,7 +66,6 @@ class VertexBasedP1DGLimiter(object):
         self.P1DG = p1dg_space
         self.P0 = p0_space
         self.P1CG = p1cg_space
-        self.dx = self.P1CG.mesh()._dx
         # create auxiliary functions
         # P0 field containing the center (mean) values of elements
         self.centroids = Function(self.P0, name='limiter_p1_dg-centroid')
@@ -85,8 +84,8 @@ class VertexBasedP1DGLimiter(object):
             tri = TrialFunction(self.P0)
             test = TestFunction(self.P0)
 
-            a = tri*test*self.dx
-            l = field*test*self.dx
+            a = tri*test*dx
+            l = field*test*dx
 
             params = {'ksp_type': 'preonly'}
             problem = LinearVariationalProblem(a, l, self.centroids)
@@ -116,7 +115,7 @@ class VertexBasedP1DGLimiter(object):
         qmin[i][0] = fmin(qmin[i][0], centroids[0][0]);
     }
     """,
-                 self.dx,
+                 dx,
                  {'qmax': (self.max_field, RW),
                   'qmin': (self.min_field, RW),
                   'centroids': (self.centroids, READ)})
@@ -139,7 +138,7 @@ class VertexBasedP1DGLimiter(object):
         q[i][0] = cellavg + alpha*(q[i][0] - cellavg);
     }
     """,
-                 self.dx,
+                 dx,
                  {'q': (field, RW),
                   'qmax': (self.max_field, READ),
                   'qmin': (self.min_field, READ),

--- a/cofs/timeintegrator.py
+++ b/cofs/timeintegrator.py
@@ -680,7 +680,6 @@ class DIRKGeneric(TimeIntegrator):
         else:
             self.solution_old = self.equation.solution
         self.funcs = self.equation.kwargs
-        dx = self.equation.dx
         test = TestFunction(self.equation.space)
 
         mixed_space = isinstance(self.equation.solution.function_space(),

--- a/examples/rhineROFI/rhineROFI.py
+++ b/examples/rhineROFI/rhineROFI.py
@@ -105,8 +105,8 @@ xyz = solver_obj.mesh2d.coordinates
 tri = TrialFunction(P1_2d)
 test = TestFunction(P1_2d)
 elev = eta_amplitude*exp(xyz[0]*kelvin_m)*cos(xyz[1]*kelvin_k - OmegaTide*bnd_time)
-a = inner(test, tri)*P1_2d.mesh()._dx
-L = test*elev*P1_2d.mesh()._dx
+a = inner(test, tri)*dx
+L = test*elev*dx
 bnd_elev_prob = LinearVariationalProblem(a, L, bnd_elev)
 bnd_elev_solver = LinearVariationalSolver(bnd_elev_prob)
 bnd_elev_solver.solve()
@@ -116,8 +116,8 @@ bnd_v = Function(fs, name='Boundary v velocity')
 tri = TrialFunction(fs)
 test = TestFunction(fs)
 v = -(g*kelvin_k/OmegaTide)*eta_amplitude*exp(xyz[0]*kelvin_m)*cos(xyz[1]*kelvin_k - OmegaTide*bnd_time)
-a = inner(test, tri)*fs.mesh()._dx
-L = test*v*fs.mesh()._dx
+a = inner(test, tri)*dx
+L = test*v*dx
 bnd_v_prob = LinearVariationalProblem(a, L, bnd_v)
 bnd_v_solver = LinearVariationalSolver(bnd_v_prob)
 bnd_v_solver.solve()
@@ -156,9 +156,9 @@ uv_init = Function(solver_obj.function_spaces.U_2d, name='initial velocity')
 #                       amp=eta_amplitude, kelvin_m=kelvin_m, kelvin_k=kelvin_k))
 tri = TrialFunction(solver_obj.function_spaces.U_2d)
 test = TestFunction(solver_obj.function_spaces.U_2d)
-a = inner(test, tri)*solver_obj.eq_sw.dx
+a = inner(test, tri)*dx
 uv = (g*kelvin_k/OmegaTide)*elev_init2
-L = test[1]*uv*solver_obj.eq_sw.dx
+L = test[1]*uv*dx
 solve(a == L, uv_init)
 salt_init3d = Function(solver_obj.function_spaces.H, name='initial salinity')
 salt_init3d.interpolate(Expression('d_ocean - (d_ocean - d_river)*(1 + tanh((x[0] - xoff)/sigma))/2',

--- a/examples/rhineROFI/rhineROFI2d.py
+++ b/examples/rhineROFI/rhineROFI2d.py
@@ -81,8 +81,8 @@ xyz = solver_obj.mesh2d.coordinates
 tri = TrialFunction(P1_2d)
 test = TestFunction(P1_2d)
 elev = eta_amplitude*exp(xyz[0]*kelvin_m)*cos(xyz[1]*kelvin_k - OmegaTide*bnd_time)
-a = inner(test, tri)*P1_2d.mesh()._dx
-L = test*elev*P1_2d.mesh()._dx
+a = inner(test, tri)*dx
+L = test*elev*dx
 bnd_elev_prob = LinearVariationalProblem(a, L, bnd_elev)
 bnd_elev_solver = LinearVariationalSolver(bnd_elev_prob)
 bnd_elev_solver.solve()
@@ -92,8 +92,8 @@ bnd_elev_solver.solve()
 # tri = TrialFunction(fs)
 # test = TestFunction(fs)
 # v = -(g*kelvin_k/OmegaTide)*eta_amplitude*exp( xyz[0]*kelvin_m )*cos( xyz[1]*kelvin_k - OmegaTide*bnd_time )
-# a = inner(test, tri)*fs.mesh()._dx
-# L = test*v*fs.mesh()._dx
+# a = inner(test, tri)*dx
+# L = test*v*dx
 # bnd_v_prob = LinearVariationalProblem(a, L, bnd_v)
 # bnd_v_solver = LinearVariationalSolver(bnd_v_prob)
 # bnd_v_solver.solve()
@@ -119,9 +119,9 @@ uv_init = Function(solver_obj.function_spaces.U_2d, name='initial velocity')
 #                      amp=eta_amplitude, kelvin_m=kelvin_m, kelvin_k=kelvin_k))
 tri = TrialFunction(solver_obj.function_spaces.U_2d)
 test = TestFunction(solver_obj.function_spaces.U_2d)
-a = inner(test, tri)*solver_obj.eq_sw.dx
+a = inner(test, tri)*dx
 uv = (g*kelvin_k/OmegaTide)*elev_init2
-L = test[1]*uv*solver_obj.eq_sw.dx
+L = test[1]*uv*dx
 solve(a == L, uv_init)
 
 

--- a/install.md
+++ b/install.md
@@ -6,7 +6,7 @@
     mercurial python-pip libopenmpi-dev openmpi-bin libblas-dev \
     liblapack-dev gfortran curl cmake cmake-data libjsoncpp0v5 \
     libspatialindex-c4v5 libspatialindex-dev libspatialindex4v5 \
-    pkg-config swig virtualenv zlib1g-dev \
+    pkg-config virtualenv zlib1g-dev \
     ipython python-scipy python-matplotlib
 
     pip install --user cachetools
@@ -17,15 +17,9 @@
 
 ```
     export PETSC_CONFIGURE_OPTIONS="--download-metis --download-parmetis --download-netcdf --download-hdf5"
-    python firedrake-install --developer --log --minimal_petsc \
-    --package_branch PyOP2 master \
-    --package_branch COFFEE master \
-    --package_branch ffc fd_bendy \
-    --package_branch ufl fd_bendy \
-    --package_branch firedrake bendy_changes
+    python firedrake-install --developer --log --minimal_petsc
 ```
 
-- Rebase firedrake `fd_bendy` with the latest compatible commit 6134b86 in `master` branch
 - Activate virtualenv
 
 ```

--- a/readme.md
+++ b/readme.md
@@ -10,9 +10,8 @@ This project is licensed under the terms of the MIT license.
 - COFS currently needs the following branches:
     - PyOP2: `master`
     - COFFEE: `master`
-    - ffc: `cofs`
-    - ufl: `cofs`
-    - firedrake: `cofs`
+    - ufl: `master`
+    - firedrake: `master`
 
 ### Installation with firedrake-install
 
@@ -20,12 +19,7 @@ This project is licensed under the terms of the MIT license.
 
 ```
     export PETSC_CONFIGURE_OPTIONS="--download-metis --download-parmetis --download-netcdf --download-hdf5"
-    python firedrake-install --developer --log --minimal_petsc \
-    --package_branch PyOP2 master \
-    --package_branch COFFEE master \
-    --package_branch ffc cofs \
-    --package_branch ufl cofs \
-    --package_branch firedrake cofs
+    python firedrake-install --developer --log --minimal_petsc
 ```
 
 - Activate virtualenv

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -46,7 +46,7 @@ def pytest_unconfigure(config):
 def pytest_runtest_teardown(item, nextitem):
     """Clear COFS caches after running a test"""
     from cofs.utility import tmp_function_cache
-    from firedrake.ffc_interface import FFCKernel
+    from firedrake.tsfc_interface import TSFCKernel
     from pyop2.op2 import Kernel
     from pyop2.base import JITModule
 
@@ -56,5 +56,5 @@ def pytest_runtest_teardown(item, nextitem):
     # Firedrake, otherwise these will never be collected.  The Kernels
     # get very big with bendy on.
     Kernel._cache.clear()
-    FFCKernel._cache.clear()
+    TSFCKernel._cache.clear()
     JITModule._cache.clear()

--- a/test/continuity3d/test_continuity_mes.py
+++ b/test/continuity3d/test_continuity_mes.py
@@ -294,8 +294,8 @@ def run(setup, refinement, order, export=True):
 
     # compute flux through bottom boundary
     normal = FacetNormal(solver_obj.mesh)
-    bottom_flux = assemble(inner(uvw, normal)*solver_obj.eq_momentum.ds_bottom)
-    bottom_flux_ana = assemble(inner(w_analytical, normal)*solver_obj.eq_momentum.ds_bottom)
+    bottom_flux = assemble(inner(uvw, normal)*ds_bottom)
+    bottom_flux_ana = assemble(inner(w_analytical, normal)*ds_bottom)
     print 'flux through bot', bottom_flux, bottom_flux_ana
 
     err_msg = '{:}: Bottom impermeability violated: bottom flux {:.4g}'.format(setup_name, bottom_flux)

--- a/test/swe2d/test_steady_state_channel_mms.py
+++ b/test/swe2d/test_steady_state_channel_mms.py
@@ -81,7 +81,7 @@ def test_steady_state_channel_mms():
         source_space = FunctionSpace(mesh2d, 'DG', order+1)
         source_func = project(source_expr, source_space)
         File('source.pvd') << source_func
-        solver_obj.timestepper.F -= solver_obj.timestepper.dt_const*solver_obj.eq_sw.U_test[0]*source_func*solver_obj.eq_sw.dx
+        solver_obj.timestepper.F -= solver_obj.timestepper.dt_const*solver_obj.eq_sw.U_test[0]*source_func*dx
         solver_obj.timestepper.update_solver()
 
         solver_obj.iterate()


### PR DESCRIPTION
The measure no longer contains mesh-specific information, and so we
don't have to a massive dance to save the correct meash object
everywhere.  Instead just use the global dx, ds, etc... as appropriate.
Move definitions of ds_bottom and ds_surf into utility.py.

Additionally, FunctionSpace objects no longer have a cdim, but rather a
shape and a dim property.  We need dim for the usages here.

Finally, now that the new form compiler has landed, we no longer have to
install a strange set of branches.